### PR TITLE
Update OSM-ISSprOM 2019.crt

### DIFF
--- a/symbol sets/OSM-ISSprOM 2019.crt
+++ b/symbol sets/OSM-ISSprOM 2019.crt
@@ -66,6 +66,7 @@
 # 710    landuse = construction
 412    landuse = farmland
 520    landuse = farmyard
+520    landuse = flowerbed
 406    landuse = forest
 401    landuse = grass
 520    landuse = industrial
@@ -78,10 +79,13 @@
 # 710    landuse = quarry
 213    landuse = quarry AND resource = sand
 520    landuse = residential
+401    landuse = residential AND residential = apartments
 414    landuse = vineyard
 
 401    leisure = park
+520    leisure = garden
 401    leisure = pitch
+520    leisure = pitch AND sport = tennis
 
 501.8  highway = cycleway
 
@@ -93,17 +97,18 @@
 501.19 highway = secondary
 501.9  highway = tertiary
 
-506    highway = path
+506    highway = path 
+501.6  highway = path AND (surface = asphalt OR surface = paving_stones OR surface = concrete OR surface = sett OR surface = paved)
 505.1  highway = path AND (smoothness = good OR smoothness = intermediate)
 506    highway = path AND (smoothness = bad OR smoothness = very_bad)
 507    highway = path AND (smoothness = horrible OR smoothness = very_horrible)
 
 
-505.2  highway = track
-501.8  highway = track AND (smoothness = good OR smoothness = intermediate)
-505.2  highway = track AND (smoothness = bad OR smoothness = very_bad)
-505.1  highway = track AND (smoothness = horrible OR smoothness = very_horrible)
 
+505.2  highway = track
+501.8  highway = track AND (smoothness = good OR smoothness = intermediate OR surface = asphalt OR surface = paving_stones OR surface = concrete OR surface = sett OR surface = paved OR tracktype=grade1)
+505.2  highway = track AND (smoothness = bad OR smoothness = very_bad) AND (surface != asphalt) AND (tracktype !=grade1)
+505.1  highway = track AND (smoothness = horrible OR smoothness = very_horrible)
 
 501.8  (highway = unclassified OR highway = residential OR highway = service OR highway = living_street)
 501.9  (highway = unclassified OR highway = residential OR highway = service OR highway = living_street) AND (surface = asphalt OR surface = concrete OR surface = concrete:plates OR surface = concrete:lanes)


### PR DESCRIPTION
Disclaimer: This is my first attempt at contributing. Please be patient with me in case I am doing stupid things. Just a few unsystematic improvements (I hope):
Added 501.6 for some tags with highway=path because often in OSM highway=path is used for paved footways, too.
Added 501.8 for similar reasons with highway=track
Added 401 for residential=apartments because this tag can be used for apartment-block residential areas, which very often are possible to enter
Added 520 for tennis courts because it helps to see them on yellow, you can then still replace with fence manually
Added 520 for gardens and flowerbeds